### PR TITLE
Ryan jung 23 change authentication to jwt

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProcessor.java
@@ -15,5 +15,7 @@ public interface IProcessor {
   boolean createMeeting(String id, String name, LocalDateTime date, boolean open);
   boolean addMember(String first, String last);
   boolean validate(String first, String last);
-  boolean attendedMeeting(String username);
+  boolean isBlacklistedToken(String jwt);
+  boolean addBlacklistedToken(String jwt);
+  boolean clearBlacklistedTokens(long tokenDuration);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/ApiRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/ApiRouter.java
@@ -225,9 +225,14 @@ public class ApiRouter {
   }
 
   private void handleCreateMeeting(RoutingContext ctx) {
-    checkAuthentication(ctx);
     HttpServerResponse response = ctx.response();
     HttpServerRequest request = ctx.request();
+
+    if (!checkAuthentication(ctx)) {
+      response.setStatusCode(403).end();
+      return;
+    }
+
     String id = "";
     String name = "";
     LocalDateTime date = null;
@@ -254,10 +259,14 @@ public class ApiRouter {
   }
 
   private void handleAttendMeeting(RoutingContext ctx) {
-    checkAuthentication(ctx);
-
     HttpServerResponse response = ctx.response();
     HttpServerRequest request = ctx.request();
+
+    if (!checkAuthentication(ctx)) {
+      response.setStatusCode(403).end();
+      return;
+    }
+
     String meetingid = "";
     String username = "";
 
@@ -309,13 +318,14 @@ public class ApiRouter {
     return builder.compact();
   }
 
-  private void checkAuthentication(RoutingContext ctx) {
+  private boolean checkAuthentication(RoutingContext ctx) {
     HttpServerRequest request = ctx.request();
     HttpServerResponse response = ctx.response();
     if (!isAuthorizedUser(request)) {
       response.putHeader("location", "/").setStatusCode(403).end();
-      return;
+      return false;
     }
+    return true;
   }
 
   public boolean isAuthorizedUser(HttpServerRequest request) {

--- a/api/src/main/java/com/codeforcommunity/rest/ApiRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/ApiRouter.java
@@ -149,10 +149,9 @@ public class ApiRouter {
       success = processor.addMember(username, password);
 
     if (success)
-      response.putHeader("location", "/login").setStatusCode(302).end();
+      response.setStatusCode(201).end();
     else {
-      response.putHeader("content-type", "text/html");
-      response.end("<h1>failed adding user, try again</h1>");
+      response.setStatusCode(400).end();
     }
   }
 
@@ -213,13 +212,15 @@ public class ApiRouter {
       boolean success = processor.addBlacklistedToken(request.headers().get("Authorization"));
 
       if (success) {
-        ctx.reroute(ctx.request().path());
+        // ctx.reroute(ctx.request().path());
+        response.setStatusCode(201).end();
       } else {
+        // what do we do when logout fails? (secuirty risk)
         response.setStatusCode(500).end();
       }
-      // what do we do when logout fails?
+
     } else {
-      response.putHeader("content-type", "text/html").end("<h1>Not Logged In</h1>");
+      response.setStatusCode(400).end();
     }
   }
 

--- a/persist/src/main/resources/db/migration/V1__Initial_Import.sql
+++ b/persist/src/main/resources/db/migration/V1__Initial_Import.sql
@@ -23,3 +23,8 @@ CREATE TABLE IF NOT EXISTS member_attended_meeting (
   CONSTRAINT fk_attended_member FOREIGN KEY (member_id) REFERENCES member (id),
   CONSTRAINT fk_attended_meeting FOREIGN KEY (meeting_id) REFERENCES meeting (id)
 );
+
+CREATE TABLE IF NOT EXISTS blacklisted_token (
+  id VARCHAR(256) NOT NULL PRIMARY KEY,
+  time_milliseconds BIGINT
+);

--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -17,7 +17,8 @@ import java.time.format.DateTimeFormatter;
 public class ProcessorImpl implements IProcessor {
 
   private final DSLContext db;
-  private int id = 10;
+  // id should really not be a static number! see down below for dynamic id, hash of username
+  //private int id = 10;
 
   public ProcessorImpl(DSLContext db) {
     this.db = db;
@@ -67,13 +68,14 @@ public class ProcessorImpl implements IProcessor {
 
   @Override
   public boolean addMember(String first, String last) {
-
+    System.out.println("adding member");
     try {
       db.execute(
           "insert into member\n" + "  (id, email, first_name, last_name, graduation_year, major, privilege_level)\n"
-              + "  values (?, 'N/A', '" + first + "', '" + last + "', \n" + "          2020, 'CS Probably', 0);",
-          this.id);
+              + "  values (?, 'N/A', ?, ?, \n" + "2020, 'CS Probably', 0);",
+          first.hashCode(), first, last);
     } catch (Exception e) {
+      e.printStackTrace();
       return false;
     }
     return true;

--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -120,16 +120,4 @@ public class ProcessorImpl implements IProcessor {
     }
     return true;
   }
-
-  /*
-   * public boolean attendedMeeting(String username ) { // will need to use
-   * meeting try { Result result =
-   * db.fetch("select id from member\n where first_name = '" + username + "'");
-   * String memberid = (String) result.getValue(0, 0); Result result1 =
-   * db.fetch("select id from meeting"); // figure out which meeting String
-   * meetingid = (String) result1.getValue(0, 0);
-   * db.execute("insert into member_attended_meeting values " + "('1'," + memberid
-   * + "," + meetingid + ");"); } catch (Exception e) { e.printStackTrace();
-   * return false; } return true; }
-   */
 }

--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -91,8 +91,6 @@ public class ProcessorImpl implements IProcessor {
 
   @Override
   public boolean isBlacklistedToken(String jwt) {
-    System.out.println("query db for blacklisted token for id = " + jwt);
-
     Result result = db.fetch("select * \n" + "   from blacklisted_token\n" + "   where id = ?;", jwt);
     if (result.isEmpty())
       return false;
@@ -101,25 +99,22 @@ public class ProcessorImpl implements IProcessor {
 
   @Override
   public boolean addBlacklistedToken(String jwt) {
-    System.out.println(jwt);
-    System.out.println(System.currentTimeMillis());
     try {
-      db.execute(
-          "insert into blacklisted_token\n" + "  (id, time_milliseconds)\n"
-              + "  values (?, ?);",
-          jwt, System.currentTimeMillis());
+      db.execute("insert into blacklisted_token\n" + "  (id, time_milliseconds)\n" + "  values (?, ?);", jwt,
+          System.currentTimeMillis());
     } catch (Exception e) {
-      // If this fails this is a security risk as there exists a token that is still technically "valid" even though the user logged out
-      System.out.println(e);
+      // If this fails this is a security risk as there exists a token that is still
+      // technically "valid" even though the user logged out
       return false;
     }
     return true;
   }
-  
+
   @Override
   public boolean clearBlacklistedTokens(long tokenDuration) {
     try {
-      db.execute("delete from blacklisted_token\n" + " where time_millisecond < ?;", System.currentTimeMillis() - tokenDuration);
+      db.execute("delete from blacklisted_token\n" + " where time_millisecond < ?;",
+          System.currentTimeMillis() - tokenDuration);
     } catch (Exception e) {
       return false;
     }

--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -68,7 +68,6 @@ public class ProcessorImpl implements IProcessor {
 
   @Override
   public boolean addMember(String first, String last) {
-    System.out.println("adding member");
     try {
       db.execute(
           "insert into member\n" + "  (id, email, first_name, last_name, graduation_year, major, privilege_level)\n"


### PR DESCRIPTION
Removed old session authentication, used Vishik's implementation of JWTs to completely rely on JWT for authentication.

Previously, logging in would create a session for each user, now each log in returns a JWT in the header which must be stored on the client side and must be sent along with every request for protected data.

Logging out requires invalidating tokens, and therefore creating a state on the backend to manage the stateless JWT. This required creating a new table in the database "blacklisted_token" to keep track of the tokens which are blacklisted. Currently this table is cleared of all expired tokens on every logout before a new blacklisted token is added.

The responses from the backend routes were also changed such that they follow more conventional API endpoints. Responses send correct status codes as well as not responding with unneeded text in the body of the response.

Here is what using the backend looks like now from signing in and creating resources to signing out and being blacklisted:

Requesting the home page:
![image](https://user-images.githubusercontent.com/23691775/68535364-5e514a80-030f-11ea-9f99-a9512a105e11.png)

Signing up as "John" "Doe".

![image](https://user-images.githubusercontent.com/23691775/68535381-bab46a00-030f-11ea-8543-e006dc3ca9ee.png)

It is now the client's responsibility to actually ask to login.

![image](https://user-images.githubusercontent.com/23691775/68535438-b0df3680-0310-11ea-8b70-c18b13672a99.png)

Now after asking to login, we are given the JWT in the headers of the response. It is the client's responsibility to save this token and use it to be authorized for requests to protected resources.

Now lets try to make some authorized changes, _without_ sending the token, we will see that it returns a 403 forbidden error.

![image](https://user-images.githubusercontent.com/23691775/68535410-4f1ecc80-0310-11ea-9692-51dabc61d2fd.png)

But now if we send it with the token we just received, we will be authorized to create the meeting!

![image](https://user-images.githubusercontent.com/23691775/68535538-e5072700-0311-11ea-9282-eb528b56545b.png)

Finally when we log out, we will see that although our token is still not expired (it has not been more than 60 minutes), we are forbidden from accessing protected resources. Additionally, for logouts the token should be deleted from storage when logging out. However, we shouldn't just trust the client to delete the JWT, and so we create a blacklist of "logged out" tokens that are not expired, but should be marked as invalid.

So lets invalidate our token by passing it to the server, letting it know that we shouldn't accept this token as valid anymore.

![image](https://user-images.githubusercontent.com/23691775/68535573-40d1b000-0312-11ea-8a58-d65587176e8d.png)

[Note: I forgot to take a screenshot of the first logout so this is a different JWT!]

Then lets try accessing the protected resource.

![image](https://user-images.githubusercontent.com/23691775/68535596-99a14880-0312-11ea-9612-e9c4d680eba1.png)

Yep! We arent allowed in, even though our token hasnt expired the server knows we are on the blacklist and are not authorized. Everything works as intended.  


