### PR TITLE
ID[29]: Added reset password email support, with the JWT reset.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,6 +46,12 @@
 			<artifactId>jbcrypt</artifactId>
 			<version>0.3m</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/javax.mail/javax.mail-api -->
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>javax.mail-api</artifactId>
+			<version>1.6.0</version>
+		</dependency>
 
 
 	</dependencies>

--- a/api/src/main/java/com/codeforcommunity/api/IProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IProcessor.java
@@ -43,4 +43,9 @@ public interface IProcessor {
   boolean addBlacklistedToken(String jti);
 
   boolean clearBlacklistedTokens(long tokenDuration);
+  
+  boolean validateEmail(String email);
+  
+  boolean changePassword(String password, String email);
+  
 }

--- a/api/src/main/java/com/codeforcommunity/util/EmailUtil.java
+++ b/api/src/main/java/com/codeforcommunity/util/EmailUtil.java
@@ -1,0 +1,64 @@
+package com.codeforcommunity.util;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import javax.mail.*;
+import javax.mail.internet.*; //dependency
+import javax.activation.*;
+
+public class EmailUtil {
+
+   public static void sendEmail(String email, String token) {
+      // Recipient's email ID needs to be mentioned.
+      String to = email;
+
+      // Sender's email ID needs to be mentioned
+      String from = "bhalla.v@husky.neu.edu"; //TODO: need to figure out
+
+      // Assuming you are sending email from localhost
+      String host = "localhost"; //TODO: need to figure out email host
+
+      // Get system properties
+      Properties properties = System.getProperties();
+
+      // Setup mail server
+      properties.setProperty("mail.smtp.host", host);
+
+      // Get the default Session object.
+      Session session = Session.getDefaultInstance(properties);
+      String hostname = "localhost";
+      
+      try {
+        InetAddress ip = InetAddress.getLocalHost();
+        hostname = ip.getHostName();
+      }
+      catch (UnknownHostException e) {
+        e.printStackTrace();
+      }
+
+      try {
+         // Create a default MimeMessage object.
+         MimeMessage message = new MimeMessage(session);
+
+         // Set From: header field of the header.
+         message.setFrom(new InternetAddress(from));
+
+         // Set To: header field of the header.
+         message.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
+
+         // Set Subject: header field
+         message.setSubject("Reset Password"); 
+         
+         String link = "http://" + hostname + ":8443/reset/password?qs=" + token; 
+         // Send the actual HTML message, as big as you like
+         message.setContent(link, "text/html"); //TODO: how to get link
+
+         // Send message
+         Transport.send(message);
+         System.out.println("Sent message successfully....");
+      } catch (MessagingException mex) {
+         mex.printStackTrace();
+      }
+   }
+}

--- a/persist/pom.xml
+++ b/persist/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <flyway.version>6.0.3</flyway.version>
     <database.driver>org.postgresql.Driver</database.driver>
-    <database.url>jdbc:postgresql://localhost:5432/c4cneu-db?autoreconnect=true</database.url>
+    <database.url>jdbc:postgresql://localhost:5434/c4cneu-db?autoreconnect=true</database.url>
     <database.username>postgres</database.username>
     <database.password>root</database.password>
   </properties>

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -34,7 +34,7 @@ public class ServiceMain {
     }
 
     // TODO: These arguments should be read out of a properties file
-    DSLContext db = DSL.using("jdbc:postgresql://localhost:5432/c4cneu-db", "postgres", "root");
+    DSLContext db = DSL.using("jdbc:postgresql://localhost:5434/c4cneu-db", "postgres", "root");
     this.db = db;
   }
 

--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -281,4 +281,21 @@ public class ProcessorImpl implements IProcessor {
     }
     return true;
   }
+
+  @Override
+  public boolean validateEmail(String email) {
+    // TODO Auto-generated method stub
+    return db.fetchExists(db.select().from(Tables.USERS).where(Tables.USERS.EMAIL.eq(email)));   
+  }
+
+  @Override
+  public boolean changePassword(String password, String email) {
+    final UpdatableBCrypt bcrypt = new UpdatableBCrypt(12);
+    if(!db.fetchExists(db.select().from(Tables.USERS).where(Tables.USERS.HASHED_PASSWORD.eq(bcrypt.hash(password))))) {
+      db.update(Tables.USERS).set(Tables.USERS.HASHED_PASSWORD, password).where(Tables.USERS.EMAIL.eq(email)).execute();
+      return true;
+    }
+    else return false;
+    
+  }
 }


### PR DESCRIPTION
Currently the send email portion needs details for send email server and host, and email itself. The reset link has a JWT token attached to identify if it is a valid request, but is in memory and can be lost on reset. The Hashmap needs to be moved to database.