### PR TITLE
Ryan jung 53 add environment variable file

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ $ psql -U postgres -d c4cneu-db -f <file> -h localhost
 
 ### Compiling & Running
 
+Update the properties file in `/persist/src/main/resources/db.properties` to contain your database connection information
+
 ```sh
 $ cd c4c-internal-backend
 $ mvn clean package

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ $ psql -U postgres -d c4cneu-db -f <file> -h localhost
 
 Update the properties file in `/persist/src/main/resources/db.properties` to contain your database connection information
 
+Update the properties file in `/persist/src/main/resources/server.properties` to contain the paths to keystores for the API and HTTP servers
+
 ```sh
 $ cd c4c-internal-backend
 $ mvn clean package

--- a/api/src/main/java/com/codeforcommunity/ApiMain.java
+++ b/api/src/main/java/com/codeforcommunity/ApiMain.java
@@ -7,6 +7,10 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.web.Router;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import io.vertx.core.net.NetServerOptions;
 
 /**
@@ -14,9 +18,24 @@ import io.vertx.core.net.NetServerOptions;
  */
 public class ApiMain {
   private final ApiRouter apiRouter;
+  private final Properties serverProperties = new Properties();
 
   public ApiMain(ApiRouter apiRouter) {
     this.apiRouter = apiRouter;
+    loadProperties();
+
+  }
+
+  /**
+   * Load properties from a server.properties file into a Properties field.
+   */
+  private void loadProperties() {
+    InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("server.properties");
+    try {
+      serverProperties.load(propertiesStream);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   /**
@@ -25,7 +44,7 @@ public class ApiMain {
   public void startApi() {
     Vertx vertx = Vertx.vertx();
     HttpServerOptions options = new HttpServerOptions().addEnabledSecureTransportProtocol("TLSv1.2").setSsl(true)
-        .setKeyStoreOptions(new JksOptions().setPath("classes/keystore.jks")
+        .setKeyStoreOptions(new JksOptions().setPath(serverProperties.getProperty("server.APIKeystorePath"))
             .setPassword("password"));
     HttpServer server = vertx.createHttpServer(options);
 
@@ -37,7 +56,7 @@ public class ApiMain {
   public void startHTTP() {
     Vertx vertx = Vertx.vertx();
     HttpServer server = vertx.createHttpServer(new HttpServerOptions().setSsl(true)
-        .setKeyStoreOptions(new JksOptions().setPath("classes/keystore.jks")
+        .setKeyStoreOptions(new JksOptions().setPath(serverProperties.getProperty("server.HTTPKeystorePath"))
             .setPassword("password")));
     Router router = Router.router(vertx);
 

--- a/persist/pom.xml
+++ b/persist/pom.xml
@@ -19,6 +19,26 @@
 
   <build>
     <plugins>
+      <!-- Read database properties file -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <files>
+                <file>src\main\resources\db.properties</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Generate jOOQ classes from our sql file -->
       <plugin>
         <groupId>org.jooq</groupId>

--- a/persist/src/main/resources/db.properties
+++ b/persist/src/main/resources/db.properties
@@ -1,0 +1,4 @@
+database.driver = org.postgresql.Driver
+database.url = jdbc:postgresql://localhost:5432/c4cneu-db?autoreconnect=true
+database.username = postgres
+database.password = root

--- a/persist/src/main/resources/server.properties
+++ b/persist/src/main/resources/server.properties
@@ -1,0 +1,3 @@
+server.APIKeystorePath = C:\\Users\\forry\\Documents\\Computer_Science\\C4C\\c4c-internal-backend\\api\\src\\main\\resources\\keystore.jks
+server.HTTPKeystorePath = C:\\Users\\forry\\Documents\\Computer_Science\\C4C\\c4c-internal-backend\\service\\src\\main\\resources\\keystore.jks
+

--- a/service/src/main/java/com/codeforcommunity/ServiceMain.java
+++ b/service/src/main/java/com/codeforcommunity/ServiceMain.java
@@ -6,8 +6,13 @@ import com.codeforcommunity.rest.ApiRouter;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class ServiceMain {
   private DSLContext db;
+  private final Properties dbProperties = new Properties();
 
   public static void main(String[] args) {
     ServiceMain serviceMain = new ServiceMain();
@@ -18,8 +23,21 @@ public class ServiceMain {
    * Start the server, get everything going.
    */
   public void initialize() {
+    loadProperties();
     connectDb();
     initializeServer();
+  }
+
+  /**
+   * Load properties from a db.properties file into a Properties field.
+   */
+  private void loadProperties() {
+    InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream("db.properties");
+    try {
+      dbProperties.load(propertiesStream);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   /**
@@ -28,13 +46,13 @@ public class ServiceMain {
   private void connectDb() {
     // This block ensures that the MySQL driver is loaded in the classpath
     try {
-      Class.forName("org.postgresql.Driver");
+      Class.forName(dbProperties.getProperty("database.driver"));
     } catch (ClassNotFoundException e) {
       e.printStackTrace();
     }
 
-    // TODO: These arguments should be read out of a properties file
-    DSLContext db = DSL.using("jdbc:postgresql://localhost:5432/c4cneu-db", "postgres", "root");
+    DSLContext db = DSL.using(dbProperties.getProperty("database.url"), dbProperties.getProperty("database.username"),
+        dbProperties.getProperty("database.password"));
     this.db = db;
   }
 


### PR DESCRIPTION
Added two new properties files in persist\src\main\resources
- db.properties
- server.properties

db.properties contains the same variables as the one in backend scaffold, we can now change the URL for the database and username/password very easily in one file

server.properties only contains the keystore paths for both the API and HTTP servers, we can now put the path to keystores in this property file

Connecting to the database and processing requests is also unaffected as shown through Insomnia below

![image](https://user-images.githubusercontent.com/23691775/72222818-ed105c80-3536-11ea-8f8a-770f6b58d872.png)


Connecting to https://localhost:8443 works correctly (although as before the certificate is invalid and chrome will give a warning message) 

![image](https://user-images.githubusercontent.com/23691775/72222794-cc480700-3536-11ea-92b8-dd7787cae1f4.png)

