### PR TITLE
deleted unused properties

### DIFF
--- a/persist/pom.xml
+++ b/persist/pom.xml
@@ -11,10 +11,6 @@
 
   <properties>
     <flyway.version>6.0.3</flyway.version>
-    <database.driver>org.postgresql.Driver</database.driver>
-    <database.url>jdbc:postgresql://localhost:5432/c4cneu-db?autoreconnect=true</database.url>
-    <database.username>postgres</database.username>
-    <database.password>root</database.password>
   </properties>
 
   <build>


### PR DESCRIPTION
Just needed to delete a few lines of code in the pom file that were redundantly setting db properties that should be initialized only in the db.properties file