### PR TITLE
Updated all JOOQ queries

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/ApplicantReturn.java
+++ b/api/src/main/java/com/codeforcommunity/dto/ApplicantReturn.java
@@ -1,10 +1,9 @@
 package com.codeforcommunity.dto;
 
-import java.time.LocalDateTime;
-
 public class ApplicantReturn {
   // doesnt make sense that we would ever set these values after construction.
   // favor immutibility.
+  private final int id;
   private final int userId;
   private final byte[] fileBLOB;
   private final String fileType;
@@ -12,8 +11,9 @@ public class ApplicantReturn {
   private final String priorInvolvement;
   private final String whyJoin;
 
-  public ApplicantReturn(int userId, byte[] fileBLOB, String fileType, String[] interests, String priorInvolvement,
-      String whyJoin) {
+  public ApplicantReturn(int id, int userId, byte[] fileBLOB, String fileType, String[] interests,
+      String priorInvolvement, String whyJoin) {
+    this.id = id;
     this.userId = userId;
     this.fileBLOB = fileBLOB;
     this.fileType = fileType;
@@ -21,6 +21,10 @@ public class ApplicantReturn {
     this.priorInvolvement = priorInvolvement;
     this.whyJoin = whyJoin;
 
+  }
+
+  public int getId() {
+    return this.id;
   }
 
   public int getUserId() {

--- a/api/src/main/java/com/codeforcommunity/dto/UserReturn.java
+++ b/api/src/main/java/com/codeforcommunity/dto/UserReturn.java
@@ -11,7 +11,7 @@ public class UserReturn {
   private final String major;
   private final int privilegeLevel;
 
-  public UserReturn(int id, String email, String firstName, String lastName, int year, String major,
+  public UserReturn(int id, String email, String firstName, String lastName, String _password, int year, String major,
       int privilegeLevel) {
     this.id = id;
     this.email = email;
@@ -21,7 +21,6 @@ public class UserReturn {
     this.major = major;
     this.privilegeLevel = privilegeLevel;
   }
-
 
   public int getId() {
     return this.id;
@@ -53,6 +52,7 @@ public class UserReturn {
 
   @Override
   public String toString() {
-    return this.id + " " + this.email + " " + this.firstName + " " + this.lastName + " " + this.year + " " + this.major + " " + this.privilegeLevel;
+    return this.id + " " + this.email + " " + this.firstName + " " + this.lastName + " " + this.year + " " + this.major
+        + " " + this.privilegeLevel;
   }
 }


### PR DESCRIPTION
I only made changes to ProcessorImpl, which holds all the JOOQ queries, and also the DTOs that needed to be changed for the JOOQ queries to work properly with methods such as .fetchInto(DTO)

During this ticket I made a few design choices
- It is probably a bad idea to split every table into its own DataProcessorImpl.java file, as that would mean having a gigantic constructor for ApiRouter, adding a lot of ugliness for no reason. Although it sucks to have all that code in one file, it all belongs there and operate on the same resource (this.db)
- I decided not to implement a DataRequest type DTO, just because I feel like it is beyond the scope of this ticket. For a future ticket, I think we should create a DataRequest DTO that has a method that mutates a given DataRecord to match its fields, this would abstract a lot of code away!
- Finally, I had to create a _password field to the constructor of UserReturn, even though it really sucks that we are passing a hashed password to any object, this is really just for convenience of using the .fetchInto() method. We dont ever store the hash in our Return object so its perfectly safe.


All tests passing on postman:

![image](https://user-images.githubusercontent.com/23691775/75833125-08a12200-5d86-11ea-9a42-ce4139de8d7f.png)
