### PR TITLE
check if stored password is null before verifying

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProcessorImpl.java
@@ -392,7 +392,7 @@ public class ProcessorImpl implements IProcessor {
       String storedPassword = db.select(Tables.USERS.HASHED_PASSWORD).from(Tables.USERS)
           .where(Tables.USERS.EMAIL.eq(email)).fetchOneInto(String.class);
 
-      return UpdatableBCrypt.verifyHash(password, storedPassword);
+      return storedPassword != null && UpdatableBCrypt.verifyHash(password, storedPassword);
     } catch (NoDataFoundException e) {
       e.printStackTrace();
       return false;


### PR DESCRIPTION
A quick one line fix to a bug found from Postman testing, stored password needs to be tested to be non-null before being thrown into the verify hash method.

Fixes a bug where if a user does not yet exist, then trying to login with result in a 500 response.